### PR TITLE
feat: enable TLS support for Redis connection

### DIFF
--- a/src/infra/services/redis/redis.service.ts
+++ b/src/infra/services/redis/redis.service.ts
@@ -8,8 +8,13 @@ export class RedisService implements OnModuleDestroy {
 
   constructor() {
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+
+    // Se a URL começa com "rediss://", habilita TLS
+    const isTls = redisUrl.startsWith('rediss://');
+
     this.client = new Redis(redisUrl, {
       maxRetriesPerRequest: 3,
+      tls: isTls ? {} : undefined, // ativa TLS se necessário
     });
 
     this.client.on('connect', () => this.logger.log('Redis conectado'));


### PR DESCRIPTION
- Added logic to enable TLS for Redis connections when the URL starts with "rediss://".
- Updated Redis client initialization to conditionally include TLS options based on the connection URL.